### PR TITLE
Improve reuqest to find transaction from operation

### DIFF
--- a/src/Repository/TransactionRepository.php
+++ b/src/Repository/TransactionRepository.php
@@ -15,6 +15,7 @@ use App\Entity\Expense;
 use App\Entity\Transaction;
 use BankStatementParser\Model\Operation;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\ORM\NonUniqueResultException;
 use Doctrine\Persistence\ManagerRegistry;
 
 /**
@@ -32,6 +33,13 @@ class TransactionRepository extends ServiceEntityRepository
         parent::__construct($registry, Transaction::class);
     }
 
+    /**
+     * @param Operation $operation
+     * @param string $accountNumber
+     * @return Transaction|null
+     *
+     * @throws NonUniqueResultException
+     */
     public function findFromOperation(Operation $operation, string $accountNumber) : ? Transaction
     {
         $qb = $this->createQueryBuilder('t')
@@ -39,6 +47,8 @@ class TransactionRepository extends ServiceEntityRepository
             ->join('statement.source', 'source')
             ->where('t.date = :date')
             ->andWhere('source.number = :accountNumber')
+            ->andWhere('t.details = :details')
+            ->setParameter('details', $operation->getDetails())
             ->setParameter('date', $operation->getDate())
             ->setParameter('accountNumber', $accountNumber);
 

--- a/src/Repository/TransactionRepository.php
+++ b/src/Repository/TransactionRepository.php
@@ -36,6 +36,7 @@ class TransactionRepository extends ServiceEntityRepository
     /**
      * @param Operation $operation
      * @param string $accountNumber
+     *
      * @return Transaction|null
      *
      * @throws NonUniqueResultException


### PR DESCRIPTION
When re-uploading a statement, the system try to find if each operation of the statement exist in the database.
There is a problem when on the same statement, there is two or more operation of the same amount, on the same day